### PR TITLE
Potential fix for code scanning alert no. 30: Server-side request forgery

### DIFF
--- a/routes/profileImageUrlUpload.ts
+++ b/routes/profileImageUrlUpload.ts
@@ -17,6 +17,11 @@ export function profileImageUrlUpload () {
   return async (req: Request, res: Response, next: NextFunction) => {
     if (req.body.imageUrl !== undefined) {
       const url = req.body.imageUrl
+      const trustedDomains = ['example.com', 'images.example.com']; // Allow-list of trusted domains
+      const parsedUrl = new URL(url);
+      if (!trustedDomains.includes(parsedUrl.hostname)) {
+        throw new Error('URL is not from a trusted domain');
+      }
       if (url.match(/(.)*solve\/challenges\/server-side(.)*/) !== null) req.app.locals.abused_ssrf_bug = true
       const loggedInUser = security.authenticatedUsers.get(req.cookies.token)
       if (loggedInUser) {


### PR DESCRIPTION
Potential fix for [https://github.com/Himanshu-Vinod-Kumar/Juice_Soap/security/code-scanning/30](https://github.com/Himanshu-Vinod-Kumar/Juice_Soap/security/code-scanning/30)

To fix the SSRF vulnerability, we need to restrict the `url` to an allow-list of trusted domains or subdomains, ensuring that user input cannot specify arbitrary or malicious URLs. Additionally, we can sanitize and validate the input to prevent path traversal or injection attacks.

**Steps to fix:**
1. Introduce an allow-list of trusted domains or subdomains for `imageUrl`.
2. Validate `url` against the allow-list before using it in the `fetch(url)` request.
3. Reject or sanitize invalid inputs to prevent unauthorized requests.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
