### PR TITLE
Potential fix for code scanning alert no. 4: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -15,7 +15,7 @@ export function trackOrder () {
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : utils.trunc(req.params.id, 60)
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/Himanshu-Vinod-Kumar/Juice_Soap/security/code-scanning/4](https://github.com/Himanshu-Vinod-Kumar/Juice_Soap/security/code-scanning/4)

To fix the issue, the user-provided input (`req.params.id`) must be properly validated and sanitized, ensuring it cannot introduce arbitrary code into the `$where` clause. The best approach is to avoid using `$where` altogether and use a safer querying method, such as parameterized queries or direct field matching (`find({ orderId: id })`).

#### Steps to implement the fix:
1. Replace the `$where` clause with a direct query using the `orderId` field.
2. Ensure the `id` variable is a valid identifier (strictly alphanumeric with optional dashes) before passing it to the database query.
3. Update the logic to handle edge cases, such as when the `id` is invalid or does not exist in the database.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
