### PR TITLE
Potential fix for code scanning alert no. 43: Missing rate limiting

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -13,6 +13,7 @@ import helmet from 'helmet'
 import http from 'node:http'
 import path from 'node:path'
 import express from 'express'
+import rateLimit from 'express-rate-limit'
 import colors from 'colors/safe'
 import serveIndex from 'serve-index'
 import bodyParser from 'body-parser'
@@ -592,7 +593,13 @@ restoreOverwrittenFilesWithOriginals().then(() => {
   app.put('/rest/continue-code/apply/:continueCode', restoreProgress.restoreProgress())
   app.get('/rest/captcha', captchas())
   app.get('/rest/image-captcha', imageCaptchas())
-  app.get('/rest/track-order/:id', trackOrder())
+  const trackOrderRateLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+    message: "Too many requests from this IP, please try again later."
+  })
+
+  app.get('/rest/track-order/:id', trackOrderRateLimiter, trackOrder())
   app.get('/rest/country-mapping', countryMapping())
   app.get('/rest/saveLoginIp', saveLoginIp())
   app.post('/rest/user/data-export', security.appendUserId(), verifyImageCaptcha())


### PR DESCRIPTION
Potential fix for [https://github.com/Himanshu-Vinod-Kumar/Juice_Soap/security/code-scanning/43](https://github.com/Himanshu-Vinod-Kumar/Juice_Soap/security/code-scanning/43)

To address the issue, we will introduce rate limiting to the application using the widely-used `express-rate-limit` package. This middleware will be applied to the `trackOrder()` route to limit the number of requests a user can make within a specified time window. Specifically:
1. Install `express-rate-limit` and configure it with appropriate limits (e.g., 100 requests per 15 minutes).
2. Create a rate limiting middleware and apply it specifically to the `trackOrder()` route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
